### PR TITLE
 <refactor>: 월간 통계 반응형 크기 조정 및 모바일 css 수정

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,21 +1,20 @@
 <script setup>
-import { useMediaQuery } from "@vueuse/core";
-import MenuBar from "@/components/common/MenuBar.vue";
-import MenuBarMobile from "@/components/common/MenuBarMobile.vue";
+import { useMediaQuery } from '@vueuse/core';
+import MenuBar from '@/components/common/MenuBar.vue';
+import MenuBarMobile from '@/components/common/MenuBarMobile.vue';
 
-const isMobile = useMediaQuery("(max-width: 394px)");
+const isMobile = useMediaQuery('(max-width: 796px)');
 </script>
 
 <template>
-    <div id="container">
-        <div><component :is="isMobile ? MenuBarMobile : MenuBar" /></div>
+  <div id="container">
+    <div><component :is="isMobile ? MenuBarMobile : MenuBar" /></div>
 
-        <div id="page-rendering-div"><RouterView /></div>
-    </div>
+    <div id="page-rendering-div"><RouterView /></div>
+  </div>
 </template>
 <style scoped>
 #container {
   display: flex; /* 가로로 배치 */
 }
-
 </style>

--- a/src/components/cashmonth/ExpenseStats.vue
+++ b/src/components/cashmonth/ExpenseStats.vue
@@ -1,15 +1,25 @@
 <template>
   <div class="app">
     <h2>지출 통계</h2>
+    <br />
+    <!--모바일 날짜 -->
+    <div class="mobile-date-selector">
+      <DateSelector :year="selectedYear" :month="selectedMonth" @changeMonth="changeMonth" />
+    </div>
+
     <div class="chart-summary-container">
       <!--chart 공간-->
       <div class="chart-area"></div>
 
       <!--날짜 바, 총액, 카테고리별 요약 배경 상자-->
       <div class="summary-box">
-        <!--날짜-->
-        <DateSelector :year="selectedYear" :month="selectedMonth" @changeMonth="changeMonth" />
-        <!--수입 총액-->
+        <!--PC 날짜-->
+        <DateSelector
+          class="desktop-date-selector"
+          :year="selectedYear"
+          :month="selectedMonth"
+          @changeMonth="changeMonth"
+        /><!--수입 총액-->
         <TotalCard :total="totalExpense" />
         <!--카테고리별 요약-->
         <SummaryCard

--- a/src/components/cashmonth/IncomeStats.vue
+++ b/src/components/cashmonth/IncomeStats.vue
@@ -1,14 +1,25 @@
 <template>
   <div class="app">
     <h2>수입 통계</h2>
+    <br />
+    <!--모바일 날짜 -->
+    <div class="mobile-date-selector">
+      <DateSelector :year="selectedYear" :month="selectedMonth" @changeMonth="changeMonth" />
+    </div>
+
     <div class="chart-summary-container">
       <!--chart 공간-->
       <div class="chart-area"></div>
 
       <!--날짜 바, 총액, 카테고리별 요약 배경 상자-->
       <div class="summary-box">
-        <!--날짜-->
-        <DateSelector :year="selectedYear" :month="selectedMonth" @changeMonth="changeMonth" />
+        <!--PC 날짜-->
+        <DateSelector
+          class="desktop-date-selector"
+          :year="selectedYear"
+          :month="selectedMonth"
+          @changeMonth="changeMonth"
+        />
         <!--수입 총액-->
         <TotalCard :total="totalIncome" />
         <!--카테고리별 요약-->
@@ -21,6 +32,7 @@
         />
       </div>
     </div>
+
     <!--수입 내역-->
     <div class="details-list">
       <h3>수입 내역</h3>

--- a/src/css/statistics.css
+++ b/src/css/statistics.css
@@ -63,7 +63,11 @@
 }
 
 /* 날짜 선택 */
-.date-selector {
+.mobile-date-selector {
+  display: none;
+}
+
+.desktop-date-selector {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -162,7 +166,7 @@
 }
 
 /* 모바일 버전 */
-@media (max-width: 600px) {
+@media (max-width: 796px) {
   .cash-statistics-view {
     margin-left: 0;
   }
@@ -185,13 +189,27 @@
     border-bottom: 2px solid #fdd835;
   }
 
-  .chart-summary-container {
-    flex-direction: column;
+  .mobile-date-selector {
+    display: flex;
+    justify-content: center;
+    margin: 1rem 0;
   }
 
-  .chart-area,
-  .summary-box {
-    width: 90%;
+  .desktop-date-selector {
+    display: none;
+  }
+
+  .mobile-date-selector .date-selector button {
+    background-color: #fdd835;
+    border: none;
+    border-radius: 50%;
+    margin: 0rem 1rem;
+    padding: 0.4rem 0.7rem;
+    font-weight: bold;
+  }
+
+  .chart-summary-container {
+    flex-direction: column;
   }
 
   .card .category {

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -1,11 +1,11 @@
 <script setup>
-import { useMediaQuery } from "@vueuse/core";
-import MainView from "@/components/MainComponent.vue";
-import MainViewMobile from "@/components/MobileMainComponent.vue";
+import { useMediaQuery } from '@vueuse/core';
+import MainView from '@/components/MainComponent.vue';
+import MainViewMobile from '@/components/MobileMainComponent.vue';
 
-const isMobile = useMediaQuery("(max-width: 394px)");
+const isMobile = useMediaQuery('(max-width: 796px)');
 </script>
 
 <template>
-    <component :is="isMobile ? MainViewMobile : MainView" />
+  <component :is="isMobile ? MainViewMobile : MainView" />
 </template>


### PR DESCRIPTION
<refactor>: 월간 통계 반응형 크기 조정 및 모바일 css 수정

1. 모바일 버전 수입, 지출 버튼 css 수정
    - IncomeStats, ExpenseStats에 mobile-date-selector 추가
    - statistics에 date-selector를 desktop-selector로 변경
    - statistics에 mobile-date-selector 추가

2. 반응형 크기 796px로 수정
    - App.vue, MainView, statistics 내 반응형 크기 796px로 수정